### PR TITLE
Change the design to prevent UB

### DIFF
--- a/examples/read_write.rs
+++ b/examples/read_write.rs
@@ -27,13 +27,15 @@ async fn main() {
         write_buf.as_mut()[i] = (i % 0xff) as u8;
     }
 
-    file.write_at(&aio_handle, 0, &write_buf, WriteFlags::APPEND)
+    let (_, write_buf) = file
+        .write_at(&aio_handle, 0, write_buf, WriteFlags::APPEND)
         .await
         .unwrap();
 
-    let mut read_buf = LockedBuf::with_size(1024).unwrap();
+    let read_buf = LockedBuf::with_size(1024).unwrap();
 
-    file.read_at(&aio_handle, 0, &mut read_buf, ReadFlags::empty())
+    let (_, read_buf) = file
+        .read_at(&aio_handle, 0, read_buf, ReadFlags::empty())
         .await
         .unwrap();
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,4 @@
-use crate::aio;
+use crate::{aio, LockedBuf};
 
 /// Represents AIO operation. See [`io_submit`](https://manpages.debian.org/testing/manpages-dev/io_submit.2.en.html)
 #[derive(Copy, Clone, Debug)]
@@ -31,7 +31,7 @@ impl Opcode {
 }
 
 /// Raw AIO command
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug)]
 pub struct RawCommand {
     /// Operation
     pub opcode: Opcode,
@@ -39,13 +39,8 @@ pub struct RawCommand {
     /// Offset in the file
     pub offset: u64,
 
-    /// Pointer to the [`LockedBuf`] in the memory, converted to `u64`
-    ///
-    /// [`LockedBuf`]: struct.LockedBuf.html
-    pub buf: u64,
-
-    /// Buffer length
-    pub len: u64,
+    /// Optional buffer
+    pub buf: Option<LockedBuf>,
 
     /// ReadFlags or WriteFlags, depending on the operation
     pub flags: u32,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,23 +3,37 @@ use std::io;
 use thiserror::Error;
 
 use crate::eventfd::EventFdError;
+use crate::LockedBuf;
 
 /// AIO command error
 #[derive(Error, Debug)]
 pub enum AioCommandError {
     /// AIO context was stopped
     #[error("AioContext stopped")]
-    AioStopped,
+    AioStopped {
+        /// LockedBuf
+        buf: Option<LockedBuf>,
+    },
 
     /// Error from [`io_submit`]
     ///
     /// [`io_submit`]: https://manpages.debian.org/testing/manpages-dev/io_submit.2.en.html
-    #[error("io_submit error: {0}")]
-    IoSubmit(io::Error),
+    #[error("io_submit error: {err}")]
+    IoSubmit {
+        /// Error
+        err: io::Error,
+        /// LockedBuf
+        buf: Option<LockedBuf>,
+    },
 
     /// Bad result received
-    #[error("bad error: `{0}`")]
-    BadResult(io::Error),
+    #[error("bad result: `{err}`")]
+    BadResult {
+        /// Error
+        err: io::Error,
+        /// LockedBuf
+        buf: Option<LockedBuf>,
+    },
 }
 
 /// AIO context creation error

--- a/tests/heavy.rs
+++ b/tests/heavy.rs
@@ -48,17 +48,19 @@ async fn load_test() {
             loop {
                 let page = thread_rng().gen_range(0, NUM_PAGES);
 
-                assert_eq!(
-                    PAGE_SIZE,
-                    file.read_at(
+                let res = file
+                    .read_at(
                         &aio_handle,
                         (page * PAGE_SIZE) as u64,
-                        &mut buffer,
-                        ReadFlags::empty()
+                        buffer,
+                        ReadFlags::empty(),
                     )
                     .await
-                    .unwrap() as usize
-                );
+                    .unwrap();
+
+                buffer = res.1;
+
+                assert_eq!(PAGE_SIZE, res.0 as usize);
             }
         }));
     }
@@ -77,17 +79,19 @@ async fn load_test() {
                 let page = thread_rng().gen_range(0, NUM_PAGES);
                 thread_rng().fill(buffer.as_mut());
 
-                assert_eq!(
-                    PAGE_SIZE,
-                    file.write_at(
+                let res = file
+                    .write_at(
                         &aio_handle,
                         (page * PAGE_SIZE) as u64,
-                        &mut buffer,
+                        buffer,
                         WriteFlags::DSYNC,
                     )
                     .await
-                    .unwrap() as usize,
-                );
+                    .unwrap();
+
+                buffer = res.1;
+
+                assert_eq!(PAGE_SIZE, res.0 as usize,);
             }
         }));
     }


### PR DESCRIPTION
Change the design, to prevent LockedBuffer drop before request completion. Additionally, properly fix `io_submit` error handling, and introduce Mutex instead of RefCell in `Request`.

Closes: #1, #2, #3