### PR TITLE
chore: migrate from memmap to memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ parking_lot = "0.12"
 intrusive-collections = "0.9.0"
 lock_api = "0.4"
 thiserror = "2"
-memmap = "0.7.0"
+memmap2 = "0.9"
 region = "3"
 bitflags = "2"
 

--- a/src/locked_buf.rs
+++ b/src/locked_buf.rs
@@ -5,7 +5,7 @@ use std::mem::ManuallyDrop;
 use std::sync::Arc;
 use std::{fmt, io};
 
-use memmap::MmapMut;
+use memmap2::MmapMut;
 use thiserror::Error;
 
 /// Error during [`LockedBuf`] creation


### PR DESCRIPTION
The memmap crate hasn't been updated in 7 years. This commit switches the dependency to the actively maintained memmap2 crate.